### PR TITLE
Fix use-after-free between C3Di_RenderTargetDestroy/SetOutput

### DIFF
--- a/source/renderqueue.c
+++ b/source/renderqueue.c
@@ -339,10 +339,17 @@ C3D_RenderTarget* C3D_RenderTargetCreateFromTex(C3D_Tex* tex, GPU_TEXFACE face, 
 
 void C3Di_RenderTargetDestroy(C3D_RenderTarget* target)
 {
+	int i;
+
 	if (target->ownsColor)
 		vramFree(target->frameBuf.colorBuf);
 	if (target->ownsDepth)
 		vramFree(target->frameBuf.depthBuf);
+	for (i = 0; i < 3; i ++)
+	{
+		if (linkedTarget[i] == target)
+			linkedTarget[i] = NULL;
+	}
 
 	C3D_RenderTarget** prevNext = target->prev ? &target->prev->next : &firstTarget;
 	C3D_RenderTarget** nextPrev = target->next ? &target->next->prev : &lastTarget;


### PR DESCRIPTION
I've noticed that `C3Di_RenderTargetDestroy` frees `target`, but never removes the pointer from the `linkedTarget` array. In the event you try to create a new render target for the same output, `C3D_RenderTargetSetOutput` sets a value in `linkedTarget[id]` if it's not null - in this case, I think this results in writing to freed memory and potentially causing memory corruption.

The scenario I noticed this in was while debugging a rare, inconsistent crash when switching 400x240 and 800x240 display modes on the top screen, which - to my understanding - currently requires a deletion and re-creation of the render target.