### PR TITLE
Add M_PI to maths, to allow compilation on C++

### DIFF
--- a/include/c3d/maths.h
+++ b/include/c3d/maths.h
@@ -9,6 +9,10 @@
  * @{
  */
 
+#ifndef M_PI
+#    define M_PI 3.14159265358979323846264338327950288
+#endif
+
 /**
  * The one true circumference-to-radius ratio.
  * See http://tauday.com/tau-manifesto


### PR DESCRIPTION
C++ does not specify `M_PI`, so this change is required to allow for compilation.