### PR TITLE
Add C3D_LightEnvBumpNormalZ()

### DIFF
--- a/include/c3d/light.h
+++ b/include/c3d/light.h
@@ -77,6 +77,14 @@ enum
 void C3D_LightEnvFresnel(C3D_LightEnv* env, GPU_FRESNELSEL selector);
 void C3D_LightEnvBumpMode(C3D_LightEnv* env, GPU_BUMPMODE mode);
 void C3D_LightEnvBumpSel(C3D_LightEnv* env, int texUnit);
+
+/**
+ * @brief Configures whether to use the z component of the normal map.
+ * @param[out] env    Pointer to light environment structure.
+ * @param[in]  enable false if the z component is reconstructed from the xy components
+ *                     of the normal map, true if the z component is taken from the normal map.
+ */
+void C3D_LightEnvBumpNormalZ(C3D_LightEnv *env, bool enable);
 void C3D_LightEnvShadowMode(C3D_LightEnv* env, u32 mode);
 void C3D_LightEnvShadowSel(C3D_LightEnv* env, int texUnit);
 void C3D_LightEnvClampHighlights(C3D_LightEnv* env, bool clamp);

--- a/source/lightenv.c
+++ b/source/lightenv.c
@@ -250,6 +250,14 @@ void C3D_LightEnvBumpSel(C3D_LightEnv* env, int texUnit)
 	env->flags |= C3DF_LightEnv_Dirty;
 }
 
+void C3D_LightEnvBumpNormalZ(C3D_LightEnv *env, bool usez) {
+	if (usez)
+		env->conf.config[0] |= BIT(30);
+	else
+		env->conf.config[0] &= ~BIT(30);
+	env->flags |= C3DF_LightEnv_Dirty;
+}
+
 void C3D_LightEnvShadowMode(C3D_LightEnv* env, u32 mode)
 {
 	mode &= 0xF<<16;


### PR DESCRIPTION
This function can be used to enable/disable recalculating the normal Z component. By default, the normal.z (blue channel) of the bump map is ignored and it is calculated based on the normal.xy components.

I verified this behavior by taking the normal_mapping example and replacing the blue channel of the normal map with black. By default, it will look exactly the same however with this setting enabled, the model will be mostly in shadow.

Looking it up, it seems like that behavior (ignoring the z component) can be desirable in some circumstances and this feature does exist in Unity and Unreal under the name "Normal Reconstruct Z" and "DeriveNormalZ".

Still it would be useful to be able to turn that off and use the Z component listed in the normal map.